### PR TITLE
Stop exposing port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,3 @@ COPY package.json .
 RUN npm install
 
 COPY . .
-
-EXPOSE 8080
-
-# CMD ["npm", "start"]


### PR DESCRIPTION
### Why?

We don't use docker to actually run the website so we don't need to expose the port
